### PR TITLE
Update test generator to build simple wall corner

### DIFF
--- a/hires_convert_map.py
+++ b/hires_convert_map.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+# Experimental converter that voxelises brushes at high resolution
+# then rebuilds larger cubes when writing the final octree.
+# This demonstrates a simple approach to "successive voxellization"
+# followed by merging ("un-voxellisation").
+
+import struct
+import gzip
+import re
+from typing import List, Dict, Tuple
+
+MAP_VERSION = 45
+WORLD_SIZE = 512
+GAME_VERSION = 281
+GAME_ID = b"fps\0"
+MAP_REVISION = 1
+
+ORIENT_INDEX = {
+    'x-': 0,
+    'x+': 1,
+    'y-': 2,
+    'y+': 3,
+    'z-': 4,
+    'z+': 5,
+}
+
+MAX_DEPTH = 5
+BASE_TEXTURE = "exx/base-crete01"
+
+pattern = re.compile(r"\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*([^\s]+)")
+
+class Brush:
+    def __init__(self):
+        self.planes: List[Tuple[Tuple[int,int,int], ...]] = []
+        self.bounds = [None, None, None, None, None, None]
+        self.textures: Dict[str, str] = {}
+
+    def add_plane(self, pts, texture):
+        self.planes.append((pts, texture))
+        xs, ys, zs = zip(*pts)
+        if self.bounds[0] is None:
+            self.bounds = [min(xs), max(xs), min(ys), max(ys), min(zs), max(zs)]
+        else:
+            self.bounds[0] = min(self.bounds[0], min(xs))
+            self.bounds[1] = max(self.bounds[1], max(xs))
+            self.bounds[2] = min(self.bounds[2], min(ys))
+            self.bounds[3] = max(self.bounds[3], max(ys))
+            self.bounds[4] = min(self.bounds[4], min(zs))
+            self.bounds[5] = max(self.bounds[5], max(zs))
+        v1 = (pts[1][0]-pts[0][0], pts[1][1]-pts[0][1], pts[1][2]-pts[0][2])
+        v2 = (pts[2][0]-pts[0][0], pts[2][1]-pts[0][1], pts[2][2]-pts[0][2])
+        nx = v1[1]*v2[2] - v1[2]*v2[1]
+        ny = v1[2]*v2[0] - v1[0]*v2[2]
+        nz = v1[0]*v2[1] - v1[1]*v2[0]
+        ax, ay, az = abs(nx), abs(ny), abs(nz)
+        if ax >= ay and ax >= az:
+            orient = 'x+' if nx > 0 else 'x-'
+        elif ay >= ax and ay >= az:
+            orient = 'y+' if ny > 0 else 'y-'
+        else:
+            orient = 'z+' if nz > 0 else 'z-'
+        self.textures[orient] = texture
+
+    def finalize(self):
+        pass
+
+def parse_valve_map(fname: str) -> List[Brush]:
+    brushes: List[Brush] = []
+    cur: Brush | None = None
+    in_world = False
+    with open(fname) as f:
+        for line in f:
+            s = line.strip()
+            if s.startswith('"classname" "worldspawn"'):
+                in_world = True
+                continue
+            if not in_world:
+                continue
+            if s.startswith('// entity 1'):
+                break
+            if s == '{':
+                cur = Brush()
+                continue
+            if s == '}' and cur is not None:
+                cur.finalize()
+                brushes.append(cur)
+                cur = None
+                continue
+            if cur is not None and s.startswith('('):
+                m = pattern.match(s)
+                if m:
+                    pts = [(int(m.group(i)), int(m.group(i+1)), int(m.group(i+2))) for i in (1,4,7)]
+                    texture = m.group(10)
+                    cur.add_plane(pts, texture)
+    return brushes
+
+def parse_player_start(fname: str):
+    origin = (0.0,0.0,0.0)
+    angle = 0.0
+    with open(fname) as f:
+        capture=False
+        for line in f:
+            s=line.strip()
+            if s.startswith('// entity 1'):
+                capture=True
+                continue
+            if capture:
+                if s.startswith('//'):
+                    break
+                if s.startswith('"origin"'):
+                    parts = s.split('"')[3].split()
+                    origin = tuple(float(p) for p in parts)
+                elif s.startswith('"angle"'):
+                    angle=float(s.split('"')[3])
+        return origin,angle
+
+def collect_bounds(brushes: List[Brush]):
+    xs=[];ys=[];zs=[]
+    for b in brushes:
+        xmin,xmax,ymin,ymax,zmin,zmax = b.bounds
+        xs.extend([xmin,xmax])
+        ys.extend([ymin,ymax])
+        zs.extend([zmin,zmax])
+    return min(xs),max(xs),min(ys),max(ys),min(zs),max(zs)
+def gather_textures(leaves: List[Leaf]):
+    names={"sky":0}
+    next_index=1
+    for leaf in leaves:
+        for tex in leaf.textures.values():
+            if tex not in names:
+                names[tex]=next_index
+                next_index+=1
+    names[BASE_TEXTURE]=names.get(BASE_TEXTURE,next_index)
+    if BASE_TEXTURE not in names:
+        names[BASE_TEXTURE]=next_index
+    return names
+
+
+class Leaf:
+    def __init__(self, depth:int, ix:int, iy:int, iz:int, start, end, textures:Dict[str,str]):
+        self.depth=depth
+        self.ix=ix; self.iy=iy; self.iz=iz
+        self.start=start
+        self.end=end
+        self.textures=textures
+
+def point_in_brush(pt, brush:Brush) -> bool:
+    x,y,z = pt
+    for plane, _ in brush.planes:
+        p0,p1,p2 = plane
+        v1 = (p1[0]-p0[0], p1[1]-p0[1], p1[2]-p0[2])
+        v2 = (p2[0]-p0[0], p2[1]-p0[1], p2[2]-p0[2])
+        nx = v1[1]*v2[2] - v1[2]*v2[1]
+        ny = v1[2]*v2[0] - v1[0]*v2[2]
+        nz = v1[0]*v2[1] - v1[1]*v2[0]
+        if (x-p0[0])*nx + (y-p0[1])*ny + (z-p0[2])*nz > 0:
+            return False
+    return True
+
+def voxellize_brush(brush:Brush, offset) -> List[Leaf]:
+    leaves=[]
+    step = WORLD_SIZE >> MAX_DEPTH
+    xmin,xmax,ymin,ymax,zmin,zmax = brush.bounds
+    x0=int(xmin+offset[0]); x1=int(xmax+offset[0])
+    y0=int(ymin+offset[1]); y1=int(ymax+offset[1])
+    z0=int(zmin+offset[2]); z1=int(zmax+offset[2])
+    gx0=(x0//step)*step
+    gx1=((x1+step-1)//step)*step
+    gy0=(y0//step)*step
+    gy1=((y1+step-1)//step)*step
+    gz0=(z0//step)*step
+    gz1=((z1+step-1)//step)*step
+    for x in range(gx0,gx1,step):
+        for y in range(gy0,gy1,step):
+            for z in range(gz0,gz1,step):
+                cx=x+step/2
+                cy=y+step/2
+                cz=z+step/2
+                if point_in_brush((cx-offset[0],cy-offset[1],cz-offset[2]), brush):
+                    ix=x//step
+                    iy=y//step
+                    iz=z//step
+                    leaves.append(Leaf(MAX_DEPTH, ix, iy, iz, [0,0,0], [8,8,8], brush.textures))
+    return leaves
+
+class Node:
+    def __init__(self):
+        self.children={}
+        self.leaf:Leaf|None=None
+
+root=Node()
+
+def insert_leaf(leaf:Leaf):
+    node=root
+    for d in range(leaf.depth):
+        shift=MAX_DEPTH-1-d
+        idx=((leaf.ix>>shift)&1) | (((leaf.iy>>shift)&1)<<1) | (((leaf.iz>>shift)&1)<<2)
+        if idx not in node.children:
+            node.children[idx]=Node()
+        node=node.children[idx]
+    node.leaf=leaf
+
+def build_tree(leaves:List[Leaf]):
+    for l in leaves:
+        insert_leaf(l)
+
+def merge(node:Node):
+    if node.leaf:
+        return node
+    for i in range(8):
+        child=node.children.get(i)
+        if child:
+            merge(child)
+    if len(node.children)==8:
+        first=node.children[0]
+        if all(c.leaf and c.leaf.textures==first.leaf.textures for c in node.children.values()):
+            tex=first.leaf.textures
+            depth=first.leaf.depth-1
+            ix=first.leaf.ix//2
+            iy=first.leaf.iy//2
+            iz=first.leaf.iz//2
+            node.children={}
+            node.leaf=Leaf(depth,ix,iy,iz,[0,0,0],[8,8,8],tex)
+    return node
+
+def encode_node(node:Node, textures:Dict[str,int]) -> bytes:
+    if node.leaf:
+        leaf=node.leaf
+        edges=[]
+        for d in range(3):
+            start=leaf.start[d]
+            end=leaf.end[d]
+            val=(end<<4)|start
+            for _ in range(4):
+                edges.append(val)
+        solid=all(e==0x88 for e in edges)
+        typ=2 if solid else 3
+        data=bytearray()
+        data.append(typ)
+        if typ==3:
+            data.extend(bytes(edges))
+        for orient in ('x-','x+','y-','y+','z-','z+'):
+            t=leaf.textures.get(orient,BASE_TEXTURE)
+            data.extend(struct.pack('<H', textures.get(t,0)))
+        return bytes(data)
+    if not node.children:
+        return struct.pack('<B6H',1,*([0]*6))
+    out=b'\x00'
+    for i in range(8):
+        child=node.children.get(i)
+        if child is None:
+            out+=struct.pack('<B6H',1,*([0]*6))
+        else:
+            out+=encode_node(child,textures)
+    return out
+
+def write_mpz(filename, rootnode:Node, textures:Dict[str,int], spawn_pos):
+    texslots=len(textures)
+    header=struct.pack('<4sii7i4s', b'MAPZ', MAP_VERSION, 44, WORLD_SIZE,
+                        1,0,0,texslots, GAME_VERSION, MAP_REVISION, GAME_ID)
+    variables=struct.pack('<i',0)
+    texmru=struct.pack('<H',texslots)+b''.join(struct.pack('<H',i) for i in range(texslots))
+    ent=struct.pack('<3fB3B', *spawn_pos, 3,0,0,0)+struct.pack('<i7i',7,*([0]*7))+struct.pack('<i',0)
+    vslots=b''.join(struct.pack('<ii',0,-1) for _ in range(texslots))
+    octree=encode_node(rootnode, textures)
+    data=header+variables+texmru+ent+vslots+octree
+    with gzip.open(filename,'wb') as f:
+        f.write(data)
+
+def write_cfg(filename, textures):
+    with open(filename,'w') as f:
+        f.write('setshader stdworld\n')
+        f.write('texture 0 textures/sky.png\n')
+        for name,idx in textures.items():
+            if name=='sky':
+                continue
+            f.write('setshader stdworld\n')
+            f.write(f'texture 0 textures/{name}.png\n')
+
+def main():
+    brushes=parse_valve_map('valve220_room.map')
+    xmin,xmax,ymin,ymax,zmin,zmax=collect_bounds(brushes)
+    def snap(v:float)->float:
+        return round(v/16)*16
+    offset=(
+        snap(WORLD_SIZE/2-(xmin+xmax)/2),
+        snap(WORLD_SIZE/2-(ymin+ymax)/2),
+        16 - zmin
+    )
+    leaves=[]
+    for b in brushes:
+        leaves.extend(voxellize_brush(b, offset))
+    textures=gather_textures(leaves)
+    build_tree(leaves)
+    merge(root)
+    start_origin,_=parse_player_start('valve220_room.map')
+    spawn=(start_origin[0]+offset[0], start_origin[1]+offset[1], start_origin[2]+offset[2])
+    write_mpz('valve220_room_vx.mpz', root, textures, spawn)
+    write_cfg('valve220_room_vx.cfg', textures)
+
+if __name__=='__main__':
+    main()

--- a/new_convert_map.py
+++ b/new_convert_map.py
@@ -1,0 +1,269 @@
+import struct
+import gzip
+import re
+from typing import List, Dict, Tuple
+
+MAP_VERSION = 45
+WORLD_SIZE = 512
+GAME_VERSION = 281
+GAME_ID = b"fps\0"
+MAP_REVISION = 1
+
+# orientation indices
+ORIENT_INDEX = {
+    'x-': 0,  # O_LEFT
+    'x+': 1,  # O_RIGHT
+    'y-': 2,  # O_BACK
+    'y+': 3,  # O_FRONT
+    'z-': 4,  # O_BOTTOM
+    'z+': 5,  # O_TOP
+}
+
+MAX_DEPTH = 5  # octree depth
+
+BASE_TEXTURE = "exx/base-crete01"
+
+pattern = re.compile(r"\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*\(\s*(-?\d+)\s+(-?\d+)\s+(-?\d+)\s*\)\s*([^\s]+)")
+
+class Brush:
+    def __init__(self):
+        self.planes: List[Tuple[Tuple[int,int,int], ...]] = []
+        self.bounds = [None, None, None, None, None, None]
+        self.textures: Dict[str, str] = {}
+
+    def add_plane(self, pts, texture):
+        self.planes.append((pts, texture))
+        xs, ys, zs = zip(*pts)
+        if self.bounds[0] is None:
+            self.bounds = [min(xs), max(xs), min(ys), max(ys), min(zs), max(zs)]
+        else:
+            self.bounds[0] = min(self.bounds[0], min(xs))
+            self.bounds[1] = max(self.bounds[1], max(xs))
+            self.bounds[2] = min(self.bounds[2], min(ys))
+            self.bounds[3] = max(self.bounds[3], max(ys))
+            self.bounds[4] = min(self.bounds[4], min(zs))
+            self.bounds[5] = max(self.bounds[5], max(zs))
+
+        v1 = (pts[1][0]-pts[0][0], pts[1][1]-pts[0][1], pts[1][2]-pts[0][2])
+        v2 = (pts[2][0]-pts[0][0], pts[2][1]-pts[0][1], pts[2][2]-pts[0][2])
+        nx = v1[1]*v2[2] - v1[2]*v2[1]
+        ny = v1[2]*v2[0] - v1[0]*v2[2]
+        nz = v1[0]*v2[1] - v1[1]*v2[0]
+        ax, ay, az = abs(nx), abs(ny), abs(nz)
+        if ax >= ay and ax >= az:
+            orient = 'x+' if nx > 0 else 'x-'
+        elif ay >= ax and ay >= az:
+            orient = 'y+' if ny > 0 else 'y-'
+        else:
+            orient = 'z+' if nz > 0 else 'z-'
+
+        self.textures[orient] = texture
+
+    def finalize(self):
+        pass
+
+def parse_valve_map(fname: str) -> List[Brush]:
+    brushes: List[Brush] = []
+    cur: Brush | None = None
+    in_world = False
+    with open(fname) as f:
+        for line in f:
+            s = line.strip()
+            if s.startswith('"classname" "worldspawn"'):
+                in_world = True
+                continue
+            if not in_world:
+                continue
+            if s.startswith('// entity 1'):
+                break
+            if s == '{':
+                cur = Brush()
+                continue
+            if s == '}' and cur is not None:
+                cur.finalize()
+                brushes.append(cur)
+                cur = None
+                continue
+            if cur is not None and s.startswith('('):
+                m = pattern.match(s)
+                if m:
+                    pts = [(int(m.group(i)), int(m.group(i+1)), int(m.group(i+2))) for i in (1,4,7)]
+                    texture = m.group(10)
+                    cur.add_plane(pts, texture)
+    return brushes
+
+def parse_player_start(fname: str):
+    origin = (0.0,0.0,0.0)
+    angle = 0.0
+    with open(fname) as f:
+        capture=False
+        for line in f:
+            s=line.strip()
+            if s.startswith('// entity 1'):
+                capture=True
+                continue
+            if capture:
+                if s.startswith('//'):
+                    break
+                if s.startswith('"origin"'):
+                    parts = s.split('"')[3].split()
+                    origin = tuple(float(p) for p in parts)
+                elif s.startswith('"angle"'):
+                    angle=float(s.split('"')[3])
+        return origin,angle
+
+def collect_bounds(brushes: List[Brush]):
+    xs=[];ys=[];zs=[]
+    for b in brushes:
+        xmin,xmax,ymin,ymax,zmin,zmax = b.bounds
+        xs.extend([xmin,xmax])
+        ys.extend([ymin,ymax])
+        zs.extend([zmin,zmax])
+    return min(xs),max(xs),min(ys),max(ys),min(zs),max(zs)
+
+class Leaf:
+    def __init__(self, depth:int, ix:int, iy:int, iz:int, start, end, textures:Dict[str,str]):
+        self.depth=depth
+        self.ix=ix; self.iy=iy; self.iz=iz
+        self.start=start
+        self.end=end
+        self.textures=textures
+
+def choose_depth(x0,x1,y0,y1,z0,z1):
+    for depth in range(0, MAX_DEPTH+1):
+        size=WORLD_SIZE>>depth
+        step=size//8
+        if all(v%step==0 for v in (x0,x1,y0,y1,z0,z1)):
+            if (x0//size)==((x1-1)//size) and (y0//size)==((y1-1)//size) and (z0//size)==((z1-1)//size):
+                return depth
+    return MAX_DEPTH
+
+def brushes_to_leaves(brushes: List[Brush], offset) -> List[Leaf]:
+    leaves=[]
+    for b in brushes:
+        xmin,xmax,ymin,ymax,zmin,zmax=b.bounds
+        x0=int(xmin+offset[0]); x1=int(xmax+offset[0])
+        y0=int(ymin+offset[1]); y1=int(ymax+offset[1])
+        z0=int(zmin+offset[2]); z1=int(zmax+offset[2])
+        depth=choose_depth(x0,x1,y0,y1,z0,z1)
+        size=WORLD_SIZE>>depth
+        step=size//8
+        ix=x0//size; iy=y0//size; iz=z0//size
+        start=[round((x0-ix*size)/step), round((y0-iy*size)/step), round((z0-iz*size)/step)]
+        end=[round((x1-ix*size)/step), round((y1-iy*size)/step), round((z1-iz*size)/step)]
+        start=[max(0,min(8,s)) for s in start]
+        end=[max(0,min(8,e)) for e in end]
+        leaves.append(Leaf(depth,ix,iy,iz,start,end,b.textures))
+    return leaves
+
+def gather_textures(leaves: List[Leaf]):
+    names={'sky':0}
+    next_index=1
+    for leaf in leaves:
+        for tex in leaf.textures.values():
+            if tex not in names:
+                names[tex]=next_index
+                next_index+=1
+    names[BASE_TEXTURE]=names.get(BASE_TEXTURE,next_index)
+    if BASE_TEXTURE not in names:
+        names[BASE_TEXTURE]=next_index
+    return names
+
+class Node:
+    def __init__(self):
+        self.children={}  # index -> Node
+        self.leaf: Leaf|None=None
+
+root=Node()
+
+def insert_leaf(leaf:Leaf):
+    node=root
+    for d in range(leaf.depth):
+        shift=MAX_DEPTH-1-d
+        idx=((leaf.ix>>shift)&1) | (((leaf.iy>>shift)&1)<<1) | (((leaf.iz>>shift)&1)<<2)
+        if idx not in node.children:
+            node.children[idx]=Node()
+        node=node.children[idx]
+    node.leaf=leaf
+
+def build_tree(leaves:List[Leaf]):
+    for l in leaves:
+        insert_leaf(l)
+
+
+def encode_node(node:Node, textures:Dict[str,int]) -> bytes:
+    if node.leaf:
+        leaf=node.leaf
+        edges=[]
+        for d in range(3):
+            start=leaf.start[d]
+            end=leaf.end[d]
+            val=(end<<4)|start
+            for x in (0,1):
+                for y in (0,1):
+                    edges.append(val)
+        solid=all(e==0x88 for e in edges)
+        typ=2 if solid else 3
+        data=bytearray()
+        data.append(typ)
+        if typ==3:
+            data.extend(bytes(edges))
+        for orient in ('x-','x+','y-','y+','z-','z+'):
+            t=leaf.textures.get(orient,'sky')
+            data.extend(struct.pack('<H', textures.get(t,0)))
+        return bytes(data)
+    if not node.children:
+        # empty cube
+        return struct.pack('<B6H',1,*([0]*6))
+    out=b'\x00'
+    for i in range(8):
+        child=node.children.get(i)
+        if child is None:
+            out+=struct.pack('<B6H',1,*([0]*6))
+        else:
+            out+=encode_node(child,textures)
+    return out
+
+def write_mpz(filename, rootnode:Node, textures:Dict[str,int], spawn_pos):
+    texslots=len(textures)
+    header=struct.pack('<4sii7i4s', b'MAPZ', MAP_VERSION, 44, WORLD_SIZE,
+                        1,0,0,texslots, GAME_VERSION, MAP_REVISION, GAME_ID)
+    variables=struct.pack('<i',0)
+    texmru=struct.pack('<H',texslots)+b''.join(struct.pack('<H',i) for i in range(texslots))
+    ent=struct.pack('<3fB3B', *spawn_pos, 3,0,0,0)+struct.pack('<i7i',7,*([0]*7))+struct.pack('<i',0)
+    vslots=b''.join(struct.pack('<ii',0,-1) for _ in range(texslots))
+    octree=encode_node(rootnode, textures)
+    data=header+variables+texmru+ent+vslots+octree
+    with gzip.open(filename,'wb') as f:
+        f.write(data)
+
+def write_cfg(filename, textures):
+    with open(filename,'w') as f:
+        f.write('setshader stdworld\n')
+        f.write('texture 0 textures/sky.png\n')
+        for name,idx in textures.items():
+            if name=='sky':
+                continue
+            f.write('setshader stdworld\n')
+            f.write(f'texture 0 textures/{name}.png\n')
+
+def main():
+    brushes=parse_valve_map('valve220_room.map')
+    xmin,xmax,ymin,ymax,zmin,zmax=collect_bounds(brushes)
+    def snap(v:float)->float:
+        return round(v/16)*16
+    offset=(
+        snap(WORLD_SIZE/2-(xmin+xmax)/2),
+        snap(WORLD_SIZE/2-(ymin+ymax)/2),
+        16 - zmin
+    )
+    leaves=brushes_to_leaves(brushes, offset)
+    textures=gather_textures(leaves)
+    build_tree(leaves)
+    start_origin,_=parse_player_start('valve220_room.map')
+    spawn=(start_origin[0]+offset[0], start_origin[1]+offset[1], start_origin[2]+offset[2])
+    write_mpz('valve220_room.mpz', root, textures, spawn)
+    write_cfg('valve220_room.cfg', textures)
+
+if __name__=='__main__':
+    main()

--- a/test.py
+++ b/test.py
@@ -52,7 +52,7 @@ def _pack_cube(tex, edges=None):
 
 
 def write_redeclipse_map(filename: str) -> None:
-    """Create a tiny Red Eclipse .mpz map with two walls and two ramp examples."""
+    """Create a tiny Red Eclipse .mpz map with two thin walls, a shallow ramp, and a diagonal ramp."""
 
     try:
         # ------------------------------------------------------------------
@@ -116,12 +116,12 @@ def write_redeclipse_map(filename: str) -> None:
         edges_wall_y = _pack_edges(0, 8, 0, 2, 0, 8)
         children.append(_pack_cube([TEXTURE_GROUND] * 6, edges_wall_y))
 
-        # child 2: sloped floor creating a ramp. The top z edges on the right
-        # half are higher so the solid cube forms a wedge the player can walk up.
+        # child 2: sloped floor forming a shallow ramp. The solid cube tapers
+        # from ground level to a quarter of its height across the X axis.
         ramp_edges = _pack_edge_list([
             (0, 8), (0, 8), (0, 8), (0, 8),  # X edges
             (0, 8), (0, 8), (0, 8), (0, 8),  # Y edges
-            (0, 4), (0, 8), (0, 4), (0, 8)   # Z edges form the ramp
+            (0, 0), (0, 2), (0, 0), (0, 2)   # Z edges form the floor wedge
         ])
         children.append(_pack_cube([TEXTURE_GROUND] * 6, ramp_edges))
 
@@ -129,7 +129,7 @@ def write_redeclipse_map(filename: str) -> None:
         diag_edges = _pack_edge_list([
             (0, 8), (0, 8), (0, 8), (0, 8),   # X edges
             (0, 8), (0, 8), (0, 8), (0, 8),   # Y edges
-            (0, 4), (0, 6), (0, 6), (0, 8)    # Z edges rise along X+Y
+            (0, 0), (0, 4), (0, 4), (0, 8)    # Z edges rise along X+Y
         ])
         children.append(_pack_cube([TEXTURE_GROUND] * 6, diag_edges))
         # remaining children are just empty space

--- a/test.py
+++ b/test.py
@@ -2,8 +2,8 @@
 
 The map demonstrates how a hidden container cube ("garbage" cube) can
 be subdivided to place brushes anywhere inside the map. Two thin wall
-segments meet at a right angle and a small sloped cube shows how edge
-data can create ramps without voxelising the entire map.
+segments meet at a corner and a small sloped cube shows how edge data
+can create ramps without voxelising the entire map.
 """
 
 import struct
@@ -134,24 +134,25 @@ def write_redeclipse_map(filename: str) -> None:
 
         garbage_children = []
 
-        # indices 6 and 7 form a corner by touching each other along the
-        # x=128 plane. index 5 contains a simple sloped cube to demonstrate
-        # non-axis aligned geometry. All other children stay empty.
+        # indices 1 and 2 meet diagonally so their cubes overlap at one
+        # corner, forming an L-shaped intersection. Index 5 contains a
+        # simple sloped cube to demonstrate non‑axis aligned geometry.
+        # All other children stay empty.
         for i in range(8):
-            if i == 6:
+            if i == 2:
                 # wall running along the Y axis
                 wall_y = _pack_edges(6, 8, 0, 8, 0, 8)
                 garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, wall_y))
-            elif i == 7:
+            elif i == 1:
                 # wall running along the X axis
-                wall_x = _pack_edges(0, 2, 0, 8, 0, 8)
+                wall_x = _pack_edges(0, 8, 6, 8, 0, 8)
                 garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, wall_x))
             elif i == 5:
-                # diagonal ramp rising from 0 to 25% height along the X axis
+                # wedge rising from 0% to 25% height along the X axis
                 slope = _pack_edge_list([
                     (0, 8), (0, 8), (0, 8), (0, 8),  # x edges
                     (0, 8), (0, 8), (0, 8), (0, 8),  # y edges
-                    (0, 2), (0, 8), (0, 2), (0, 8)   # z edges
+                    (0, 0), (0, 2), (0, 0), (0, 2)   # z edges
                 ])
                 garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, slope))
             else:

--- a/test.py
+++ b/test.py
@@ -1,4 +1,10 @@
-"""Generate a tiny Red Eclipse map for experimentation."""
+"""Generate a tiny Red Eclipse map for experimentation.
+
+The map demonstrates how a hidden container cube ("garbage" cube) can
+be subdivided to place brushes anywhere inside the map. Two thin wall
+segments meet at a right angle and a small sloped cube shows how edge
+data can create ramps without voxelising the entire map.
+"""
 
 import struct
 import gzip
@@ -128,16 +134,26 @@ def write_redeclipse_map(filename: str) -> None:
 
         garbage_children = []
 
-        # indices 0..5 stay empty, index 6 and 7 hold the two wall pieces that
-        # meet at a corner. They demonstrate that brushes can be placed at an
-        # arbitrary position by dividing the garbage cube.
+        # indices 6 and 7 form a corner by touching each other along the
+        # x=128 plane. index 5 contains a simple sloped cube to demonstrate
+        # non-axis aligned geometry. All other children stay empty.
         for i in range(8):
             if i == 6:
-                wall_y = _pack_edges(0, 8, 0, 2, 0, 8)
+                # wall running along the Y axis
+                wall_y = _pack_edges(6, 8, 0, 8, 0, 8)
                 garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, wall_y))
             elif i == 7:
-                wall_x = _pack_edges(6, 8, 0, 8, 0, 8)
+                # wall running along the X axis
+                wall_x = _pack_edges(0, 2, 0, 8, 0, 8)
                 garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, wall_x))
+            elif i == 5:
+                # diagonal ramp rising from 0 to 25% height along the X axis
+                slope = _pack_edge_list([
+                    (0, 8), (0, 8), (0, 8), (0, 8),  # x edges
+                    (0, 8), (0, 8), (0, 8), (0, 8),  # y edges
+                    (0, 2), (0, 8), (0, 2), (0, 8)   # z edges
+                ])
+                garbage_children.append(_pack_cube([TEXTURE_GROUND] * 6, slope))
             else:
                 garbage_children.append(_empty_cube())
 

--- a/test.py
+++ b/test.py
@@ -52,7 +52,7 @@ def _pack_cube(tex, edges=None):
 
 
 def write_redeclipse_map(filename: str) -> None:
-    """Create a tiny Red Eclipse .mpz map with two walls and a sloped floor."""
+    """Create a tiny Red Eclipse .mpz map with two walls and two ramp examples."""
 
     try:
         # ------------------------------------------------------------------
@@ -116,17 +116,24 @@ def write_redeclipse_map(filename: str) -> None:
         edges_wall_y = _pack_edges(0, 8, 0, 2, 0, 8)
         children.append(_pack_cube([TEXTURE_GROUND] * 6, edges_wall_y))
 
-        # child 2: sloped floor creating a ramp. The bottom z edges on the right
-        # half are raised so the floor inclines toward X.
-        slope_edges = _pack_edge_list([
+        # child 2: sloped floor creating a ramp. The top z edges on the right
+        # half are higher so the solid cube forms a wedge the player can walk up.
+        ramp_edges = _pack_edge_list([
             (0, 8), (0, 8), (0, 8), (0, 8),  # X edges
             (0, 8), (0, 8), (0, 8), (0, 8),  # Y edges
-            (0, 8), (4, 8), (0, 8), (4, 8)   # Z edges form the slope
+            (0, 4), (0, 8), (0, 4), (0, 8)   # Z edges form the ramp
         ])
-        children.append(_pack_cube([TEXTURE_GROUND] * 6, slope_edges))
+        children.append(_pack_cube([TEXTURE_GROUND] * 6, ramp_edges))
 
-        # remaining six children are just empty space
-        for _ in range(5):
+        # child 3: diagonal ramp approximating a 45 degree rotation
+        diag_edges = _pack_edge_list([
+            (0, 8), (0, 8), (0, 8), (0, 8),   # X edges
+            (0, 8), (0, 8), (0, 8), (0, 8),   # Y edges
+            (0, 4), (0, 6), (0, 6), (0, 8)    # Z edges rise along X+Y
+        ])
+        children.append(_pack_cube([TEXTURE_GROUND] * 6, diag_edges))
+        # remaining children are just empty space
+        for _ in range(4):
             children.append(_pack_cube([TEXTURE_SKY] * 6))
 
         octree = b"".join(children)

--- a/test.py
+++ b/test.py
@@ -100,11 +100,14 @@ def write_redeclipse_map(filename: str) -> None:
 
         children = []
 
-        # child 0: wall running along the Y axis (thin in X)
-        edges_wall_x = _pack_edges(0, 2, 0, 8, 0, 8)
+        # child 0: wall running along the Y axis (thin in X). By shifting the
+        # X edges to the higher end of the cube we align the wall with the
+        # boundary shared with child 1 so both walls meet neatly.
+        edges_wall_x = _pack_edges(6, 8, 0, 8, 0, 8)
         children.append(_pack_cube([TEXTURE_GROUND] * 6, edges_wall_x))
 
-        # child 1: wall running along the X axis (thin in Y)
+        # child 1: wall running along the X axis (thin in Y). Its Y edges are
+        # shifted to the lower end to touch the wall from child 0.
         edges_wall_y = _pack_edges(0, 8, 0, 2, 0, 8)
         children.append(_pack_cube([TEXTURE_GROUND] * 6, edges_wall_y))
 

--- a/test.py
+++ b/test.py
@@ -129,7 +129,7 @@ def write_redeclipse_map(filename: str) -> None:
         diag_edges = _pack_edge_list([
             (0, 8), (0, 8), (0, 8), (0, 8),   # X edges
             (0, 8), (0, 8), (0, 8), (0, 8),   # Y edges
-            (0, 0), (0, 4), (0, 4), (0, 8)    # Z edges rise along X+Y
+            (0, 0), (0, 4), (0, 8), (0, 4)    # Z edges rise diagonally
         ])
         children.append(_pack_cube([TEXTURE_GROUND] * 6, diag_edges))
         # remaining children are just empty space


### PR DESCRIPTION
## Summary
- enhance `test.py` to demonstrate shaped cubes
- create a minimal map with two thin walls forming a corner

## Testing
- `python3 -m py_compile test.py`
- `python3 test.py`

------
https://chatgpt.com/codex/tasks/task_e_68477a2015a88322a30610f52e0bd754